### PR TITLE
test(xray-service): add comprehensive test suite for signal service

### DIFF
--- a/apps/xray-service/src/signals/signal.controller.spec.ts
+++ b/apps/xray-service/src/signals/signal.controller.spec.ts
@@ -1,0 +1,297 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { SignalController } from './signal.controller';
+import { SignalService } from './signal.service';
+import { CreateXrayDto } from './dto/create-xray.dto';
+import { UpdateXrayDto } from './dto/update-xray.dto';
+import { XrayData } from './schema/xray-schema';
+
+describe('SignalController', () => {
+  let controller: SignalController;
+  let service: jest.Mocked<SignalService>;
+
+  // Common test data
+  const mockXrayData = {
+    _id: new Types.ObjectId('507f1f77bcf86cd799439011'),
+    deviceId: 'device-001',
+    time: new Date('2024-01-01T10:00:00.000Z'),
+    dataLength: 1024,
+    dataVolume: 2048,
+    kV: 100,
+    mA: 200,
+    exposureTime: 100,
+    projectionType: 'AP',
+  };
+
+  const baseCreateDto: CreateXrayDto = {
+    deviceId: 'device-001',
+    time: '2024-01-01T10:00:00.000Z',
+    dataLength: 1024,
+    dataVolume: 2048,
+  };
+
+  const testId = '507f1f77bcf86cd799439011';
+
+  const mockSignalService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    findWithFilters: jest.fn(),
+  };
+
+  // Helper functions
+  const createHttpException = (message: string, status: HttpStatus) =>
+    new HttpException(message, status);
+
+  const expectServiceCall = (method: keyof SignalService, args?: unknown[]) => {
+    const mockMethod = service[method] as jest.Mock;
+    if (args) {
+      expect(mockMethod).toHaveBeenCalledWith(...args);
+    } else {
+      expect(mockMethod).toHaveBeenCalled();
+    }
+  };
+
+  const testErrorHandling = async (
+    method: keyof SignalController,
+    args: unknown[],
+    expectedStatus: HttpStatus,
+    errorMessage?: string,
+  ) => {
+    const serviceError = new Error(errorMessage || 'Service error');
+    const mockMethod = service[method] as jest.Mock;
+    mockMethod.mockRejectedValue(serviceError);
+
+    const controllerMethod = controller[method] as (
+      ...args: unknown[]
+    ) => Promise<unknown>;
+    await expect(controllerMethod.apply(controller, args)).rejects.toThrow(
+      createHttpException(errorMessage || 'Service error', expectedStatus),
+    );
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SignalController],
+      providers: [
+        {
+          provide: SignalService,
+          useValue: mockSignalService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SignalController>(SignalController);
+    service = module.get(SignalService);
+
+    // Clear all mocks before each test
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a new signal', async () => {
+      const createXrayDto: CreateXrayDto = {
+        ...baseCreateDto,
+        kV: 100,
+        mA: 200,
+        exposureTime: 100,
+        projectionType: 'AP',
+      };
+
+      service.create.mockResolvedValue(mockXrayData as XrayData);
+
+      const result = await controller.create(createXrayDto);
+
+      expectServiceCall('create', [createXrayDto]);
+      expect(result).toBe(mockXrayData);
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      await testErrorHandling(
+        'create',
+        [baseCreateDto],
+        HttpStatus.BAD_REQUEST,
+        'Database connection failed',
+      );
+    });
+
+    it('should throw HttpException with generic message when no error message', async () => {
+      await testErrorHandling(
+        'create',
+        [baseCreateDto],
+        HttpStatus.BAD_REQUEST,
+        '',
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all signals', async () => {
+      const mockSignals = [
+        mockXrayData,
+        { ...mockXrayData, deviceId: 'device-002' },
+      ];
+      service.findAll.mockResolvedValue(mockSignals as XrayData[]);
+
+      const result = await controller.findAll();
+
+      expectServiceCall('findAll');
+      expect(result).toBe(mockSignals);
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      await testErrorHandling(
+        'findAll',
+        [],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        'Database query failed',
+      );
+    });
+
+    it('should throw HttpException with generic message when no error message', async () => {
+      await testErrorHandling(
+        'findAll',
+        [],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        '',
+      );
+    });
+  });
+
+  describe('findWithFilters', () => {
+    const testFilters = {
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: '2024-01-02T00:00:00.000Z',
+      deviceId: 'device-001',
+      projectionType: 'AP',
+    };
+
+    it('should return filtered signals with all parameters', async () => {
+      const mockSignals = [mockXrayData];
+      service.findWithFilters.mockResolvedValue(mockSignals as XrayData[]);
+
+      const result = await controller.findWithFilters(
+        testFilters.startDate,
+        testFilters.endDate,
+        testFilters.deviceId,
+        testFilters.projectionType,
+      );
+
+      expectServiceCall('findWithFilters', [
+        {
+          startDate: new Date(testFilters.startDate),
+          endDate: new Date(testFilters.endDate),
+          deviceId: testFilters.deviceId,
+          projectionType: testFilters.projectionType,
+        },
+      ]);
+      expect(result).toBe(mockSignals);
+    });
+
+    it('should handle partial filters', async () => {
+      const mockSignals = [mockXrayData];
+      const deviceId = 'device-001';
+
+      service.findWithFilters.mockResolvedValue(mockSignals as XrayData[]);
+
+      const result = await controller.findWithFilters(
+        undefined,
+        undefined,
+        deviceId,
+        undefined,
+      );
+
+      expectServiceCall('findWithFilters', [{ deviceId }]);
+      expect(result).toBe(mockSignals);
+    });
+
+    it('should handle no filters', async () => {
+      const mockSignals = [mockXrayData];
+      service.findWithFilters.mockResolvedValue(mockSignals as XrayData[]);
+
+      const result = await controller.findWithFilters();
+
+      expectServiceCall('findWithFilters', [{}]);
+      expect(result).toBe(mockSignals);
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      await testErrorHandling(
+        'findWithFilters',
+        ['2024-01-01'],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        'Filter query failed',
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a signal by id', async () => {
+      service.findOne.mockResolvedValue(mockXrayData as XrayData);
+
+      const result = await controller.findOne(testId);
+
+      expectServiceCall('findOne', [testId]);
+      expect(result).toBe(mockXrayData);
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      await testErrorHandling(
+        'findOne',
+        [testId],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        'Signal not found',
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a signal', async () => {
+      const updateXrayDto: UpdateXrayDto = {
+        kV: 120,
+        mA: 250,
+      };
+
+      const updatedSignal = { ...mockXrayData, ...updateXrayDto };
+      service.update.mockResolvedValue(updatedSignal as XrayData);
+
+      const result = await controller.update(testId, updateXrayDto);
+
+      expectServiceCall('update', [testId, updateXrayDto]);
+      expect(result).toBe(updatedSignal);
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      const updateXrayDto: UpdateXrayDto = { kV: 120 };
+      await testErrorHandling(
+        'update',
+        [testId, updateXrayDto],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        'Update failed',
+      );
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a signal', async () => {
+      service.remove.mockResolvedValue(undefined);
+
+      const result = await controller.remove(testId);
+
+      expectServiceCall('remove', [testId]);
+      expect(result).toEqual({ message: 'Signal deleted successfully' });
+    });
+
+    it('should throw HttpException when service fails', async () => {
+      await testErrorHandling(
+        'remove',
+        [testId],
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        'Delete failed',
+      );
+    });
+  });
+});

--- a/apps/xray-service/src/signals/signal.service.spec.ts
+++ b/apps/xray-service/src/signals/signal.service.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Logger } from '@nestjs/common';
+import { SignalService } from './signal.service';
+import { XrayData } from './schema/xray-schema';
+import { CreateXrayDto } from './dto/create-xray.dto';
+import { UpdateXrayDto } from './dto/update-xray.dto';
+
+describe('SignalService', () => {
+  let service: SignalService;
+
+  // Test data factory
+  const createMockXrayData = (overrides = {}) => ({
+    _id: '507f1f77bcf86cd799439011',
+    deviceId: 'device-001',
+    time: new Date('2024-01-01T10:00:00.000Z'),
+    dataLength: 1024,
+    dataVolume: 2048,
+    kV: 100,
+    mA: 200,
+    exposureTime: 100,
+    projectionType: 'AP',
+    ...overrides,
+  });
+
+  const mockXrayData = createMockXrayData();
+
+  // DTO factory
+  const createXrayDto = (overrides = {}): CreateXrayDto => ({
+    deviceId: 'device-001',
+    time: '2024-01-01T10:00:00.000Z',
+    dataLength: 1024,
+    dataVolume: 2048,
+    kV: 100,
+    mA: 200,
+    exposureTime: 100,
+    projectionType: 'AP',
+    ...overrides,
+  });
+
+  const mockModel = Object.assign(
+    jest.fn().mockImplementation(() => ({
+      save: jest.fn().mockResolvedValue(mockXrayData),
+    })),
+    {
+      find: jest.fn(),
+      findById: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+      findByIdAndDelete: jest.fn(),
+      create: jest.fn(),
+      countDocuments: jest.fn(),
+    }
+  );
+
+  // Helper to create mock document
+  const createMockDocument = (
+    data = mockXrayData,
+    saveResult = mockXrayData,
+  ) => ({
+    ...data,
+    save: jest.fn().mockResolvedValue(saveResult),
+  });
+
+  // Helper to mock query with exec
+  const mockQueryWithExec = (result: any) => ({
+    exec: jest.fn().mockResolvedValue(result),
+  });
+
+  beforeEach(async () => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Reset mocks
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SignalService,
+        {
+          provide: getModelToken(XrayData.name),
+          useValue: mockModel,
+        },
+      ],
+    }).compile();
+
+    service = module.get<SignalService>(SignalService);
+
+    // Mock Logger to prevent console output during tests
+    jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('processAndSaveSignal', () => {
+    it('should process and save a valid signal', async () => {
+      const dto = createXrayDto();
+      const mockDocument = createMockDocument();
+      mockModel.mockReturnValue(mockDocument);
+
+      const result = await service.processAndSaveSignal(dto);
+
+      expect(mockModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deviceId: dto.deviceId,
+          time: dto.time,
+        }),
+      );
+      expect(mockDocument.save).toHaveBeenCalled();
+      expect(result).toBe(mockXrayData);
+    });
+
+    it('should throw error for invalid payload', async () => {
+      const invalidDto = createXrayDto({
+        deviceId: undefined,
+      });
+
+      await expect(service.processAndSaveSignal(invalidDto)).rejects.toThrow(
+        'Invalid x-ray payload: missing deviceId',
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new signal', async () => {
+      const dto = createXrayDto({ deviceId: 'device-005' });
+      const mockDocument = createMockDocument();
+      mockModel.mockReturnValue(mockDocument);
+
+      const result = await service.create(dto);
+
+      expect(mockModel).toHaveBeenCalledWith(dto);
+      expect(mockDocument.save).toHaveBeenCalled();
+      expect(result).toBe(mockXrayData);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all signals without filter', async () => {
+      const mockSignals = [
+        createMockXrayData(),
+        createMockXrayData({ deviceId: 'device-002' }),
+      ];
+      mockModel.find.mockReturnValue(mockQueryWithExec(mockSignals) as any);
+
+      const result = await service.findAll();
+
+      expect(mockModel.find).toHaveBeenCalledWith({});
+      expect(result).toBe(mockSignals);
+    });
+  });
+
+  describe('findOne', () => {
+    const testId = '507f1f77bcf86cd799439011';
+
+    it('should return a signal by id', async () => {
+      mockModel.findById.mockReturnValue(
+        mockQueryWithExec(mockXrayData) as any,
+      );
+
+      const result = await service.findOne(testId);
+
+      expect(mockModel.findById).toHaveBeenCalledWith(testId);
+      expect(result).toBe(mockXrayData);
+    });
+
+    it('should handle not found', async () => {
+      const notFoundId = '507f1f77bcf86cd799439012';
+      mockModel.findById.mockReturnValue(mockQueryWithExec(null) as any);
+
+      await expect(service.findOne(notFoundId)).rejects.toThrow(
+        'Signal not found',
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a signal', async () => {
+      const testId = '507f1f77bcf86cd799439011';
+      const updateDto: UpdateXrayDto = { kV: 120, mA: 250 };
+      const updatedSignal = createMockXrayData(updateDto);
+
+      mockModel.findByIdAndUpdate.mockReturnValue(
+        mockQueryWithExec(updatedSignal) as any,
+      );
+
+      const result = await service.update(testId, updateDto);
+
+      expect(mockModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        testId,
+        updateDto,
+        { new: true },
+      );
+      expect(result).toBe(updatedSignal);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a signal', async () => {
+      const testId = '507f1f77bcf86cd799439011';
+      mockModel.findByIdAndDelete.mockReturnValue(
+        mockQueryWithExec(mockXrayData) as any,
+      );
+
+      await service.remove(testId);
+
+      expect(mockModel.findByIdAndDelete).toHaveBeenCalledWith(testId);
+    });
+  });
+
+  describe('findWithFilters', () => {
+    const mockSignals = [createMockXrayData()];
+
+    it('should find signals with date range filter', async () => {
+      const filters = {
+        startDate: new Date('2024-01-01T00:00:00.000Z'),
+        endDate: new Date('2024-01-02T00:00:00.000Z'),
+      };
+      mockModel.find.mockReturnValue(mockQueryWithExec(mockSignals) as any);
+
+      const result = await service.findWithFilters(filters);
+
+      expect(mockModel.find).toHaveBeenCalledWith({
+        time: {
+          $gte: filters.startDate,
+          $lte: filters.endDate,
+        },
+      });
+      expect(result).toBe(mockSignals);
+    });
+
+    it('should find signals with device filter', async () => {
+      const filters = { deviceId: 'device-001' };
+      mockModel.find.mockReturnValue(mockQueryWithExec(mockSignals) as any);
+
+      const result = await service.findWithFilters(filters);
+
+      expect(mockModel.find).toHaveBeenCalledWith(filters);
+      expect(result).toBe(mockSignals);
+    });
+  });
+});


### PR DESCRIPTION
- Add SignalService unit tests with mocking and edge case coverage
- Add SignalController unit tests for API endpoint validation
- Test CRUD operations, filtering, pagination, and error handling
- Ensure proper test coverage for all signal service functionality
- Establish testing foundation for maintainable signal service code